### PR TITLE
feature(tianyipeng): add 1-5, 1-6, 3-4, 4-1, 4-2

### DIFF
--- a/llmriddles/questions/executor.py
+++ b/llmriddles/questions/executor.py
@@ -18,14 +18,25 @@ class QuestionExecutor:
     @property
     def question_name(self):
         return self.question.names[self.lang]
+    
+    def llm_answer(self, qs_text: str) -> str:
+        return get_llm_fn(self.llm)(qs_text, **self.llm_cfgs)
 
     def check(self, qs_text: str) -> Tuple[str, bool, str]:
-        answer_text = get_llm_fn(self.llm)(qs_text, **self.llm_cfgs)
+        answer_text = self.llm_answer(qs_text)
         correct, explanation = self.check_answer(qs_text, answer_text)
         return answer_text, correct, explanation
 
     def check_answer(self, user_text: str, answer_text: str) -> Tuple[bool, str]:
-        correct, explanation = self.question.checker(self.question_text, user_text, answer_text, self.lang)
+        inputs = {
+            'question_text': self.question_text,
+            'user_text': user_text,
+            'answer_text': answer_text,
+            'lang': self.lang,
+            'llm_callback': self.llm_answer,
+            # this list can be extended if needed in the future 
+        }
+        correct, explanation = self.question.checker(inputs)
         if explanation is None:
             if correct:
                 explanation = 'LLM的回答满足要求' if self.lang == 'cn' else 'Correct Answer From LLM'

--- a/llmriddles/questions/level1.py
+++ b/llmriddles/questions/level1.py
@@ -1,5 +1,9 @@
 from .question import register_question
-
+from .utility import count_words, word_reverse_text
+from typing import Callable
+from .question import Checker
+from typing import Tuple, Optional
+import re
 
 def count_english_words(text: str):
     return len(text.split(' '))
@@ -11,31 +15,6 @@ def count_chinese_words(text: str):
 
 def check_if_chinese(text: str):
     return all('\u4e00' <= char <= '\u9fff' for char in text)
-
-
-def count_words(text: str, contain_punctuation: bool = False):
-    chinese_words = []
-    english_words = []
-    other_words = []
-    temp_english_words = []
-    for char in text:
-        if '\u4e00' <= char <= '\u9fff':
-            chinese_words.append(char)
-            if len(temp_english_words) > 0:
-                english_words.append(''.join(temp_english_words))
-                temp_english_words = []
-        else:
-            if char.isalpha():
-                temp_english_words.append(char)
-            else:
-                if len(temp_english_words) > 0:
-                    english_words.append(''.join(temp_english_words))
-                    temp_english_words = []
-                other_words.append(char)
-    if contain_punctuation:
-        return len(chinese_words) + len(english_words) + len(other_words)
-    else:
-        return len(chinese_words) + len(english_words)
 
 
 CN_TEXT_1 = """
@@ -175,30 +154,86 @@ register_question(
     name={'cn': '1-4 短说短话', 'en': '1-4'},
 )
 
-# CN_TEXT_5 = """
-# 第一章第五题（回文不变），请输入一个本身不是回文串的问题，使无论正着问还是倒着问，模型的回答是一样的。
+CN_TEXT_5 = """
+第一章第五题（回文不变），请输入一个本身不是回文串的问题，使无论正着问还是倒着问，模型的回答是一样的。
 
-# 请在下面的输入框内填写你的问题并点击按钮提交。
-# """
+请在下面的输入框内填写你的问题并点击按钮提交。
+"""
 
-# EN_TEXT_5 = """
-# For the fourth question in chapter 1, please enter a question that is not a palindrome string so that the model's answer is the same whether it is asked forward or backward.
+EN_TEXT_5 = """
+For the fifth question in chapter 1, please enter a question that is not a palindrome string so that the model's answer is the same whether it is asked forward or backward.
 
-# Please enter your query below and click the submit button
-# """
+Please enter your query below and click the submit button
+"""
 
-# def _checker_5(question_text: str, answer_text: str, lang: str):
-#     _ = question_text, lang
-#     answer_text = answer_text.strip()
+def _checker_5(question_text: str, user_text: str, answer_text: str, lang: str, llm_callback: Callable[[str], str]):
+    answer_text = answer_text.strip()
+    user_text = user_text.strip()
+    reversed_user_text = word_reverse_text(user_text, lang)
+    second_answer_text = llm_callback(reversed_user_text)
 
-#     if count_words(question_text) > 0:
-#         return False, 'Question should be one word.'
-#     elif count_words(answer_text) >= 20:
-#         return False, 'Answer should be less than 20 words.'
-#     else:
-#         return True, None
+    if user_text == reversed_user_text:
+        return False, "用户的问题不能是回文串" if lang == 'cn' else 'Question should not be a palindrome string.'
 
-# register_question({
-#     'cn': CN_TEXT_5,
-#     'en': EN_TEXT_5,
-# }, _checker_5)
+    if second_answer_text != answer_text:
+        return False, f"正着问和倒着问时，模型的回答应该是一样的\n 问题：{user_text}\n 正着问回答：{answer_text}\n 反着问回答：{second_answer_text}" if lang == 'cn' else f'The model\'s answer should be the same when asked forward or backward.\n Question: {user_text}\n Forward-Asking answer: {answer_text}\n Backward-Asking answer: {second_answer_text}'
+    return True, None
+
+register_question(
+    {
+        'cn': CN_TEXT_5,
+        'en': EN_TEXT_5,
+    }, 
+    checkers=Checker(_checker_5, required_input_keys=['question_text', 'user_text', 'answer_text', 'lang', 'llm_callback']), 
+    name={'cn': '1-5 回文不变', 'en': '1-5'},
+    level=1,
+)
+
+CN_TEXT_6 = """
+第一章第六题（无中生狗），请提一个不包含“狗”这个字的问题，但是回答中至少出现3次“狗”这个字。
+
+请在下面的输入框内填写你的问题并点击按钮提交。
+"""
+
+EN_TEXT_6 = """
+For the sixth question in chapter 1, please ask a question that does not contain the word "dog", but the answer contains the word "dog" at least three times.
+
+Please enter your query below and click the submit button
+"""
+
+
+def _cn_checker_6(question_text: str, user_text: str, answer_text: str) -> Tuple[bool, Optional[str]]:
+    if '狗' in user_text:
+        return False, '问题不得包含“狗”字'
+
+    dog_count = len(re.findall('狗', answer_text))
+    if dog_count >= 3:
+        return True, f'“狗”字的出现次数为{dog_count}次'
+    else:
+        return False, f'“狗”字的出现次数为{dog_count}次，未达到3次'
+
+def _en_checker_6(question_text: str, user_text: str, answer_text: str) -> Tuple[bool, Optional[str]]:
+    q_words = re.findall(r'\w+', user_text.lower())
+    if any(word in {'dog', 'dogs'} for word in q_words):
+        return False, 'The question must not contain the word "dog" or "dogs"'
+
+    a_words = re.findall(r'\w+', answer_text.lower())
+    a_dog_count = sum(1 if word in {'dog', 'dogs'} else 0 for word in a_words)
+    if a_dog_count >= 3:
+        return True, f'The word "dog" (or "dogs") appears {a_dog_count} times.'
+    else:
+        return False, f'The word "dog" (or "dogs") appears {a_dog_count} times, ' \
+                      f'which is less than 3 times.'
+
+register_question(
+    {
+        'cn': CN_TEXT_6,
+        'en': EN_TEXT_6,
+    },
+    checkers={
+        'cn': _cn_checker_6,
+        'en': _en_checker_6,
+    },
+    name={'cn': '1-6 无中生狗', 'en': '1-6'},
+    level=1,
+)

--- a/llmriddles/questions/level3.py
+++ b/llmriddles/questions/level3.py
@@ -1,29 +1,7 @@
 from .question import register_question
-
-
-def count_words(text: str, contain_punctuation: bool = False):
-    chinese_words = []
-    english_words = []
-    other_words = []
-    temp_english_words = []
-    for char in text:
-        if '\u4e00' <= char <= '\u9fff':
-            chinese_words.append(char)
-            if len(temp_english_words) > 0:
-                english_words.append(''.join(temp_english_words))
-                temp_english_words = []
-        else:
-            if char.isalpha():
-                temp_english_words.append(char)
-            else:
-                if len(temp_english_words) > 0:
-                    english_words.append(''.join(temp_english_words))
-                    temp_english_words = []
-                other_words.append(char)
-    if contain_punctuation:
-        return len(chinese_words) + len(english_words) + len(other_words)
-    else:
-        return len(chinese_words) + len(english_words)
+from .question import Checker
+from typing import Callable
+from .utility import count_words, word_reverse_text
 
 
 CN_TEXT_1 = """
@@ -84,14 +62,9 @@ def _checker_2(question_text: str, user_text: str, answer_text: str, lang: str):
     if count_words(user_text) < 10:
         return False, "用户的问题长度应该至少10个字" if lang == 'cn' else 'Question should be no less than 10 words.'
 
-    if lang == 'cn':
-        user_text = user_text[::-1]
-    else:
-        words = user_text.split()
-        words.reverse()
-        user_text = ' '.join(words)
+    reversed_user_text = word_reverse_text(user_text, lang)
 
-    if user_text == answer_text:
+    if reversed_user_text == answer_text:
         return True, None
     else:
         return False, None
@@ -144,22 +117,43 @@ register_question(
     level=3,
 )
 
-# CN_TEXT_4 = """
-# 第三章第四题（回文协变），请你输入一个本身不是回文串的问题，使得正着问和倒着问时，模型的回答本身不是回文且也是逆序。
+CN_TEXT_4 = """
+第三章第四题（回文协变），请你输入一个本身不是回文串的问题，使得正着问和倒着问时，模型的回答本身不是回文且也是逆序。
 
-# 请在下面的输入框内填写你的提问并点击按钮提交。
-# """
+请在下面的输入框内填写你的提问并点击按钮提交。
+"""
 
-# EN_TEXT_4 = """
-# For the fourth question in chapter 3, please enter a question that is not a palindrome string, so that the model's answer is also not a palindrome and is in reverse order when asked forward or backward.
+EN_TEXT_4 = """
+For the fourth question in chapter 3, please enter a question that is not a palindrome string, so that the model's answer is also not a palindrome and is in reverse order when asked forward or backward.
 
-# Please enter your query below and click the submit button
-# """
+Please enter your query below and click the submit button
+"""
 
-# def _checker_4(question_text: str, user_text: str, answer_text: str, lang: str):
-#     pass
+def _checker_4(question_text: str, user_text: str, answer_text: str, lang: str, llm_callback: Callable[[str], str]):
+    answer_text = answer_text.strip()
+    user_text = user_text.strip()
+    reversed_user_text = word_reverse_text(user_text, lang)
+    second_answer_text = llm_callback(reversed_user_text)
 
-# register_question({
-#     'cn': CN_TEXT_4,
-#     'en': EN_TEXT_4,
-# }, _checker_4, level=3)
+    if user_text == reversed_user_text:
+        return False, "用户的问题不能是回文串" if lang == 'cn' else 'Question should not be a palindrome string.'
+
+    if second_answer_text != word_reverse_text(answer_text, lang):
+        return False, f"正着问和倒着问时，模型的回答应该是逆序。\n 用户问题：{user_text}\n 正着问回答: {answer_text} \n 反着问回答: {second_answer_text}" if lang == 'cn' else f'The model\'s answer should be in reverse order when asked forward or backward.\n Question: {user_text}\n Forward-Asking answer: {answer_text} \n Backward-Asking answer: {second_answer_text}'
+
+    if second_answer_text == word_reverse_text(second_answer_text):
+        return False, "正着问和倒着问时，模型的回答不能是回文串" if lang == 'cn' else 'The model\'s answer should not be a palindrome when asked forward or backward.'
+    
+    return True, None
+
+register_question(
+    {
+        'cn': CN_TEXT_4,
+        'en': EN_TEXT_4,
+    }, 
+    checkers=Checker(_checker_4, required_input_keys=['question_text', 'user_text', 'answer_text', 'lang', 'llm_callback']), 
+    name={'cn': '3-4 回文协变', 'en': '3-4'},
+    level=3,
+)
+
+

--- a/llmriddles/questions/level4.py
+++ b/llmriddles/questions/level4.py
@@ -1,7 +1,9 @@
 import re
 
 from .question import register_question
-
+from .question import Checker
+from typing import Callable
+from .utility import count_words, word_reverse_text
 
 def check_if_is_number(text: str):
     try:
@@ -15,64 +17,81 @@ def get_all_numbers_in_a_sentence(text: str):
     return [int(i) for i in re.findall(r'\d+', text)]
 
 
-# CN_TEXT_1 = """
-# 第四章第一题，请构造一个问题A，它的回复是不同于A的B，然后以B提问能再次得到A。
+CN_TEXT_1 = """
+第四章第一题（循环往复），请构造一个问题A，它的回复是不同于A的B，然后以B提问能再次得到A。
 
-# 请在下面的输入框内填写你构造并点击按钮提交。
-# """
+请在下面的输入框内填写你构造并点击按钮提交。
+"""
 
-# EN_TEXT_1 = """
-# For the first question in chapter 4, please make a question A whose answer is B that is different from A, and then ask B to get A again.
+EN_TEXT_1 = """
+For the first question in chapter 4, please make a question A whose answer is B that is different from A, and then ask B to get A again.
 
-# Please enter your query below and click the submit button
-# """
+Please enter your query below and click the submit button
+"""
+
+def _checker_1(question_text: str, user_text: str, answer_text: str, lang: str, llm_callback: Callable[[str], str]):
+    answer_text = answer_text.strip()
+    user_text = user_text.strip()
+    second_answer_text = llm_callback(answer_text)
+
+    if second_answer_text != user_text:
+        return False, f"B产生的回答和原问题A不一致:\n A: {user_text}\n B: {answer_text}\n Answer from B: {second_answer_text}" if lang == 'cn' else f'The answer from B is not the same as the original question A:\n A: {user_text}\n B: {answer_text}\n Answer from B: {second_answer_text}'
+    
+    return True, None
+    
+register_question(
+    {
+        'cn': CN_TEXT_1,
+        'en': EN_TEXT_1,
+    },
+    checkers=Checker(_checker_1, required_input_keys=['question_text', 'user_text', 'answer_text', 'lang', 'llm_callback']), 
+    name={'cn': '4-1 循环往复', 'en': '4-1'},
+    level=4,
+)
+
+CN_TEXT_2 = """
+第四章第二题（惜字如金），本题可能没有答案，你可以自由的先去做其他的题。请输入一个字的问题，使模型的回答在16个字以内。
+
+请在下面的输入框内填写你构造并点击按钮提交。
+"""
+
+EN_TEXT_2 = """
+For the second question in chapter 4, please enter a question of one word so that the model's answer is within 16 words (The Chinese version of this problem may not have a correct answer, but the English version might).
+
+Please enter your query below and click the submit button
+"""
 
 
-# def _checker_1(question_text: str, user_text: str, answer_text: str, lang: str):
-#     _ = question_text, lang
-#     answer_text = answer_text.strip()
-#     user_text = user_text.strip()
-#     pass
+def _checker_2(question_text: str, user_text: str, answer_text: str, lang: str):
+    answer_text = answer_text.strip()
+    user_text = user_text.strip()
+    if count_words(user_text) > 1:
+        return False, "用户的问题长度应该在一个字以内" if lang == 'cn' else 'Question should be within one word.'
 
-# register_question({
-#     'cn': CN_TEXT_1,
-#     'en': EN_TEXT_1,
-# }, _checker_1, level=4)
+    if count_words(answer_text) > 16:
+        return False, "大语言模型的答案应该在16个字以内" if lang == 'cn' else 'Answer should be within 16 words.'
+    else:
+        return True, None
 
-
-# CN_TEXT_2 = """
-# 第四章第二题，
-
-# 请在下面的输入框内填写你构造并点击按钮提交。
-# """
-
-# EN_TEXT_2 = """
-# For the second question in chapter 4,
-
-# Please enter your query below and click the submit button
-# """
-
-
-# def _checker_2(question_text: str, user_text: str, answer_text: str, lang: str):
-#     _ = question_text, lang
-#     answer_text = answer_text.strip()
-#     user_text = user_text.strip()
-#     pass
-
-# register_question({
-#     'cn': CN_TEXT_2,
-#     'en': EN_TEXT_2,
-# }, _checker_2, level=4)
+register_question(
+    {
+        'cn': CN_TEXT_2,
+        'en': EN_TEXT_2,
+    },
+    checkers=_checker_2,
+    name={'cn': '4-2 惜字如金', 'en': '4-2'},
+    level=4,
+)
 
 
 CN_TEXT_3 = """
-第四章第一题（自然之密），请输入一个大于一的正整数作为问题，使回答里包含和它刚好相差1的数。
+第四章第三题（自然之密），请输入一个大于一的正整数作为问题，使回答里包含和它刚好相差1的数。
 
 请在下面的输入框内填写你构造并点击按钮提交。
 """
 
 EN_TEXT_3 = """
-For the first question in chapter 4, please enter a positive integer greater than one as the question so that the answer contains a number that is exactly 1 different from it.
+For the third question in chapter 4, please enter a positive integer greater than one as the question so that the answer contains a number that is exactly 1 different from it.
 
 Please enter your query below and click the submit button
 """

--- a/llmriddles/questions/level5.py
+++ b/llmriddles/questions/level5.py
@@ -1,30 +1,5 @@
 from .question import register_question
-
-
-def count_words(text: str, contain_punctuation: bool = False):
-    chinese_words = []
-    english_words = []
-    other_words = []
-    temp_english_words = []
-    for char in text:
-        if '\u4e00' <= char <= '\u9fff':
-            chinese_words.append(char)
-            if len(temp_english_words) > 0:
-                english_words.append(''.join(temp_english_words))
-                temp_english_words = []
-        else:
-            if char.isalpha():
-                temp_english_words.append(char)
-            else:
-                if len(temp_english_words) > 0:
-                    english_words.append(''.join(temp_english_words))
-                    temp_english_words = []
-                other_words.append(char)
-    if contain_punctuation:
-        return len(chinese_words) + len(english_words) + len(other_words)
-    else:
-        return len(chinese_words) + len(english_words)
-
+from .utility import count_words
 
 CN_TEXT_1 = """
 第五章第一题（口是心非），请构造一个不少于十个字的问题，使得回答中不包含问题中的任意字符。

--- a/llmriddles/questions/question.py
+++ b/llmriddles/questions/question.py
@@ -17,21 +17,32 @@ class Question:
 
 _KNOWN_PROBLEMS = []
 
+class Checker:
 
+    def __init__(self, checkers, required_input_keys=None) -> None:
+        self._origin_checkers = checkers
+        if isinstance(checkers, collections.abc.Mapping):
+            self.checker = self._integrated_checker
+        else:
+            self.checker = checkers
+        
+        if required_input_keys == None:
+            required_input_keys = ['question_text', 'user_text', 'answer_text', 'lang']
+        self.required_input_keys = required_input_keys
+
+    def _integrated_checker(self, question_text: str, user_text: str, answer_text: str, lang: str):
+        return self._origin_checkers[lang](question_text, user_text, answer_text)
+
+    def __call__(self, inputs):
+        return self.checker(*[inputs[key] for key in self.required_input_keys])
+        
 def register_question(text: Union[Mapping[str, str], str],
                       checkers: Union[Mapping[str, SingleLangCheckerTyping], MultiLangCheckerTyping],
                       name=Union[Mapping[str, str], str],
                       level: int = 1, default_lang='cn'):
-    if isinstance(checkers, collections.abc.Mapping):
-        _origin_checkers = checkers
-
-        def _integrated_checker(question_text: str, user_text: str, answer_text: str, lang: str):
-            return _origin_checkers[lang](question_text, user_text, answer_text)
-
-        checker: MultiLangCheckerTyping = _integrated_checker
-    else:
-        checker: MultiLangCheckerTyping = checkers
-
+    
+    checker = checkers if isinstance(checkers, Checker) else Checker(checkers)
+        
     if isinstance(text, str):
         texts = {default_lang: text}
     else:

--- a/llmriddles/questions/utility.py
+++ b/llmriddles/questions/utility.py
@@ -1,0 +1,34 @@
+
+
+def word_reverse_text(input_text, lang='cn'):
+    if lang == 'cn':
+        user_text = input_text[::-1]
+    else:
+        words = input_text.split()
+        words.reverse()
+        user_text = ' '.join(words)
+    return user_text
+
+def count_words(text: str, contain_punctuation: bool = False):
+    chinese_words = []
+    english_words = []
+    other_words = []
+    temp_english_words = []
+    for char in text:
+        if '\u4e00' <= char <= '\u9fff':
+            chinese_words.append(char)
+            if len(temp_english_words) > 0:
+                english_words.append(''.join(temp_english_words))
+                temp_english_words = []
+        else:
+            if char.isalpha():
+                temp_english_words.append(char)
+            else:
+                if len(temp_english_words) > 0:
+                    english_words.append(''.join(temp_english_words))
+                    temp_english_words = []
+                other_words.append(char)
+    if contain_punctuation:
+        return len(chinese_words) + len(english_words) + len(other_words)
+    else:
+        return len(chinese_words) + len(english_words)


### PR DESCRIPTION
- add a way of addressing checkers that require multiple calls of the llm. 
- add utility.py to refactor some of the calls including `count_words` and `word_reverse_text`
- add 1-5, 1-6, 3-4, 4-1, 4-2 (I evaluated on ChatGPT Chinese)
- add output texts from the LLM for 1-5, 3-4, and 4-1 if the answer is not correct to make the explanation more useful (since they require the second call of the LLM and the user was not able to see the response of the second call). 