### PR TITLE
增加zhipuai sdk版本约束

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ tqdm
 requests>=2.20
 gradio==4.1.1
 openai>=1
-zhipuai
+zhipuai==1.0.7
 sympy


### PR DESCRIPTION
zhipuai sdk 在版本 2.* 后不再支持项目中使用的 zhipuai.model.invoke() 方法